### PR TITLE
use correct npm package for uglify-js

### DIFF
--- a/lib/packer.js
+++ b/lib/packer.js
@@ -13,7 +13,7 @@
  */
 var fs      = require( 'fs' );
 var css_min = require( 'clean-css' );
-var js_min  = require( 'uglify-js2' );
+var js_min  = require( 'uglify-js' );
 
 var concat = function ( files ){
   var out = '';

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author"      : "dreamerslab <ben@dreamerslab.com>",
   "dependencies": {
     "clean-css"  : "0.8.0",
-    "uglify-js2" : "2.1.2"
+    "uglify-js" : "2.1.2"
   },
   "repository"  : {
     "type": "git",


### PR DESCRIPTION
The `uglify-js2` npm package should now be installed as `uglify-js` since it was re-named.  The `uglify-js2` package is deprecated.
